### PR TITLE
soc: ti_k3: am6x: enable cache for R5 cores

### DIFF
--- a/soc/ti/k3/am6x/r5/soc.c
+++ b/soc/ti/k3/am6x/r5/soc.c
@@ -8,6 +8,7 @@
 #include <zephyr/fatal.h>
 
 #include "soc.h"
+#include <zephyr/cache.h>
 #include <common/ctrl_partitions.h>
 
 unsigned int z_soc_irq_get_active(void)
@@ -51,5 +52,10 @@ int z_soc_irq_is_enabled(unsigned int irq)
 
 void soc_early_init_hook(void)
 {
+	sys_cache_data_disable();
+	sys_cache_instr_disable();
+	sys_cache_data_enable();
+	sys_cache_instr_enable();
+
 	k3_unlock_all_ctrl_partitions();
 }


### PR DESCRIPTION
Enable cache during soc early init for Cortex-R5F cores in the TI AM6x series.