### PR TITLE
Add TI RTI watchdog driver support for am243x-evm

### DIFF
--- a/boards/ti/am243x_evm/am243x_evm_am2434_m4.dts
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_m4.dts
@@ -24,6 +24,7 @@
 
 	aliases {
 		led0 = &ld26;
+		watchdog0 = &mcu_rti0;
 	};
 
 	cpus {
@@ -75,5 +76,9 @@
 
 &main_mbox6 {
 	usr-id = <3>;
+	status = "okay";
+};
+
+&mcu_rti0 {
 	status = "okay";
 };

--- a/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
@@ -6,7 +6,7 @@
 /dts-v1/;
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
-#include <ti/am64x_r5.dtsi>
+#include <ti/am64x_r5f0_0.dtsi>
 #include "am243x_evm_am2434_r5f0_0-pinctrl.dtsi"
 
 / {
@@ -25,6 +25,7 @@
 	aliases {
 		led0 = &ld26;
 		adc0 = &main_adc0;
+		watchdog0 = &main_rti8;
 	};
 
 	leds: leds {
@@ -181,6 +182,10 @@
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <4>;
 	};
+};
+
+&main_rti8 {
+	status = "okay";
 };
 
 &main_mbox6 {

--- a/dts/arm/ti/am64x_m4.dtsi
+++ b/dts/arm/ti/am64x_m4.dtsi
@@ -77,3 +77,8 @@
 	interrupts = <57 4>;
 	interrupt-parent = <&nvic>;
 };
+
+&mcu_rti0 {
+	interrupts = <19 4>;
+	interrupt-parent = <&nvic>;
+};

--- a/dts/arm/ti/am64x_r5f0_0.dtsi
+++ b/dts/arm/ti/am64x_r5f0_0.dtsi
@@ -10,3 +10,8 @@
 	usr-id = <0>;
 	status = "okay";
 };
+
+&main_rti8 {
+	interrupts = <0 0 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&vim>;
+};

--- a/dts/arm/ti/am64x_r5f0_1.dtsi
+++ b/dts/arm/ti/am64x_r5f0_1.dtsi
@@ -10,3 +10,8 @@
 	usr-id = <1>;
 	status = "okay";
 };
+
+&main_rti9 {
+	interrupts = <0 0 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&vim>;
+};

--- a/dts/arm/ti/am64x_r5f1_0.dtsi
+++ b/dts/arm/ti/am64x_r5f1_0.dtsi
@@ -10,3 +10,8 @@
 	usr-id = <0>;
 	status = "okay";
 };
+
+&main_rti10 {
+	interrupts = <0 0 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&vim>;
+};

--- a/dts/arm/ti/am64x_r5f1_1.dtsi
+++ b/dts/arm/ti/am64x_r5f1_1.dtsi
@@ -10,3 +10,8 @@
 	usr-id = <1>;
 	status = "okay";
 };
+
+&main_rti11 {
+	interrupts = <0 0 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&vim>;
+};

--- a/dts/vendor/ti/am64x_main.dtsi
+++ b/dts/vendor/ti/am64x_main.dtsi
@@ -272,6 +272,54 @@
 		#size-cells = <0>;
 	};
 
+	main_rti0: watchdog@e000000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0xe000000 0x100>;
+		clock-frequency = <DT_FREQ_M(3)>;
+		power-domains = <&rti0_pd>;
+		status = "disabled";
+	};
+
+	main_rti1: watchdog@e010000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0xe010000 0x100>;
+		clock-frequency = <DT_FREQ_M(3)>;
+		power-domains = <&rti1_pd>;
+		status = "disabled";
+	};
+
+	main_rti8: watchdog@e080000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0xe080000 0x100>;
+		clock-frequency = <DT_FREQ_M(3)>;
+		power-domains = <&rti8_pd>;
+		status = "disabled";
+	};
+
+	main_rti9: watchdog@e090000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0xe090000 0x100>;
+		clock-frequency = <DT_FREQ_M(3)>;
+		power-domains = <&rti9_pd>;
+		status = "disabled";
+	};
+
+	main_rti10: watchdog@e0a0000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0xe0a0000 0x100>;
+		clock-frequency = <DT_FREQ_M(3)>;
+		power-domains = <&rti10_pd>;
+		status = "disabled";
+	};
+
+	main_rti11: watchdog@e0b0000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0xe0b0000 0x100>;
+		clock-frequency = <DT_FREQ_M(3)>;
+		power-domains = <&rti11_pd>;
+		status = "disabled";
+	};
+
 	/* users: r5f0_0, r5f0_1, r5f1_0, r5f1_1 */
 	main_mbox0: mailbox@29000000 {
 		compatible = "ti,omap-mailbox";

--- a/dts/vendor/ti/am64x_mcu.dtsi
+++ b/dts/vendor/ti/am64x_mcu.dtsi
@@ -81,4 +81,12 @@
 		#size-cells = <0>;
 		status = "disabled";
 	};
+
+	mcu_rti0: watchdog@4880000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0x4880000 0x100>;
+		clock-frequency = <DT_FREQ_M(3)>;
+		power-domains = <&mcu_rti0_pd>;
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
- Change the dtsi to include only r5f0_0
- Add main_rti0 and main_rti1 for a53 cores
- Add main_rti8 through main_rti11 for respective r5 cores
- Add mcu_rti0 for the m4 core
- Adds watchdog support for TI am243x-evm on r5f0_0 and m4 core
- Add callback support in the existing driver

These changes are tested on am243x-evm on both r5f0_0 and m4 cores.

PR: https://github.com/zephyrproject-rtos/zephyr/pull/100291

