### PR TITLE
drivers: i2c: i2c_omap: fix FIFO byte count extraction

### DIFF
--- a/drivers/i2c/i2c_omap.c
+++ b/drivers/i2c/i2c_omap.c
@@ -22,6 +22,7 @@
 LOG_MODULE_REGISTER(omap_i2c, CONFIG_I2C_LOG_LEVEL);
 
 #define I2C_OMAP_TIMEOUT     100U
+#define I2C_OMAP_TRANSFER_TIMEOUT 1000U
 /* OCP_SYSSTATUS bit definitions */
 #define SYSS_RESETDONE_MASK  BIT(0)
 #define RETRY                -1
@@ -539,7 +540,7 @@ static int i2c_omap_transfer_message(const struct device *dev, struct i2c_msg *m
 {
 	struct i2c_omap_data *data = DEV_DATA(dev);
 	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
-	unsigned long time_left = 1000;
+	k_timepoint_t end;
 	uint16_t control_reg;
 	int result = 0;
 	/* Determine message direction (read or write) and update the receiver flag */
@@ -579,10 +580,10 @@ static int i2c_omap_transfer_message(const struct device *dev, struct i2c_msg *m
 	i2c_base_addr->CON = control_reg;
 	/* Poll for status until the transfer is complete */
 	/* Call a lower-level function to continue the transfer */
+	end = sys_timepoint_calc(K_MSEC(I2C_OMAP_TRANSFER_TIMEOUT));
 	do {
 		result = i2c_omap_transfer_message_ll(dev);
-		time_left--;
-	} while (result == RETRY && time_left);
+	} while (result == RETRY && !sys_timepoint_expired(end));
 
 	/* If no errors occurred, return success */
 	if (!result) {

--- a/drivers/i2c/i2c_omap.c
+++ b/drivers/i2c/i2c_omap.c
@@ -167,7 +167,7 @@ static int i2c_omap_reset(const struct device *dev)
 	struct i2c_omap_data *data = DEV_DATA(dev);
 	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 	uint64_t timeout;
-	uint16_t sysc;
+	uint32_t sysc;
 
 	sysc = i2c_base_addr->SYSC;
 	i2c_base_addr->CON &= ~I2C_OMAP_CON_EN;
@@ -456,7 +456,7 @@ static int i2c_omap_transfer_message_ll(const struct device *dev)
 {
 	struct i2c_omap_data *data = DEV_DATA(dev);
 	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
-	uint16_t stat = i2c_base_addr->STAT, result = 0;
+	uint32_t stat = i2c_base_addr->STAT, result = 0;
 	uint8_t num_bytes;
 
 	if (data->receiver) {

--- a/drivers/i2c/i2c_omap.c
+++ b/drivers/i2c/i2c_omap.c
@@ -13,6 +13,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/sys/util.h>
 
 #ifdef CONFIG_I2C_OMAP_BUS_RECOVERY
 #include "i2c_bitbang.h"
@@ -26,6 +27,8 @@ LOG_MODULE_REGISTER(omap_i2c, CONFIG_I2C_LOG_LEVEL);
 #define RETRY                -1
 #define I2C_BITRATE_FAST     400000
 #define I2C_BITRATE_STANDARD 100000
+#define I2C_BUFSTAT_RX_MASK  GENMASK(13, 8)
+#define I2C_BUFSTAT_TX_MASK  GENMASK(5, 0)
 
 /* I2C Registers */
 typedef struct {
@@ -277,6 +280,7 @@ static void i2c_omap_transmit_receive_data(const struct device *dev, uint8_t num
 		} else {
 			i2c_base_addr->DATA = *(buf_ptr++);
 		}
+		data->current_msg.len--;
 	}
 }
 
@@ -452,6 +456,7 @@ static int i2c_omap_transfer_message_ll(const struct device *dev)
 	struct i2c_omap_data *data = DEV_DATA(dev);
 	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 	uint16_t stat = i2c_base_addr->STAT, result = 0;
+	uint8_t num_bytes;
 
 	if (data->receiver) {
 		stat &= ~(I2C_OMAP_STAT_XDR | I2C_OMAP_STAT_XRDY);
@@ -479,9 +484,10 @@ static int i2c_omap_transfer_message_ll(const struct device *dev)
 
 	/* Handle receive logic */
 	if (stat & (I2C_OMAP_STAT_RRDY | I2C_OMAP_STAT_RDR)) {
-		int buffer =
-			(stat & I2C_OMAP_STAT_RRDY) ? i2c_base_addr->BUF : i2c_base_addr->BUFSTAT;
-		i2c_omap_transmit_receive_data(dev, buffer);
+		num_bytes = FIELD_GET(I2C_BUFSTAT_RX_MASK, i2c_base_addr->BUFSTAT);
+		if (num_bytes > 0) {
+			i2c_omap_transmit_receive_data(dev, num_bytes);
+		}
 		i2c_base_addr->STAT |=
 			(stat & I2C_OMAP_STAT_RRDY) ? I2C_OMAP_STAT_RRDY : I2C_OMAP_STAT_RDR;
 		return RETRY;
@@ -489,9 +495,10 @@ static int i2c_omap_transfer_message_ll(const struct device *dev)
 
 	/* Handle transmit logic */
 	if (stat & (I2C_OMAP_STAT_XRDY | I2C_OMAP_STAT_XDR)) {
-		int buffer =
-			(stat & I2C_OMAP_STAT_XRDY) ? i2c_base_addr->BUF : i2c_base_addr->BUFSTAT;
-		i2c_omap_transmit_receive_data(dev, buffer);
+		num_bytes = FIELD_GET(I2C_BUFSTAT_TX_MASK, i2c_base_addr->BUFSTAT);
+		if (num_bytes > 0) {
+			i2c_omap_transmit_receive_data(dev, num_bytes);
+		}
 		i2c_base_addr->STAT |=
 			(stat & I2C_OMAP_STAT_XRDY) ? I2C_OMAP_STAT_XRDY : I2C_OMAP_STAT_XDR;
 		return RETRY;


### PR DESCRIPTION
This PR adds the following:

- Adds FIFO byte count extraction from BUFSTAT register which was previously not present causing multi-byte transfers to fail. BUFSTAT[13:8] holds values for Rx byte count and BUFSTAT[5:0] holds values for Tx.
- Changes the existing timeout logic during transfer which used a fixed decrement loop for polling which runs at different speeds on different cores. Changed to a constant time 1000ms to be consistent across all cores.
- Fixed improper type usage for i2c registers in functions.

Tested on TI sk-am62x

PR: https://github.com/zephyrproject-rtos/zephyr/pull/103390