### PR TITLE
UPSTREAM-PEND: dts: vendor: ti: Add RTC node for AM62L board

### DIFF
--- a/boards/ti/am62l_evm/am62l_evm_am62l3_a53.dts
+++ b/boards/ti/am62l_evm/am62l_evm_am62l3_a53.dts
@@ -146,3 +146,7 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&main_rtc0 {
+	status = "okay";
+};

--- a/dts/vendor/ti/am62l-main.dtsi
+++ b/dts/vendor/ti/am62l-main.dtsi
@@ -411,4 +411,21 @@
 		clocks = <&scmi_clk 101>;
 		status = "disabled";
 	};
+
+	main_rtc0: rtc@2b1f0000 {
+		compatible = "ti,k3-rtc-counter";
+		reg = <0x2b1f0000 0x64>;
+		clock-frequency = <DT_FREQ_K(32)>;
+		clocks = <&scmi_clk 272>;
+		interrupts = <GIC_SPI 28 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		power-domains = <&main_rtc0_pd>;
+		status = "disabled";
+
+		counter_rtc0: counter_rtc {
+			compatible = "zephyr,rtc-counter";
+			alarms-count = <2>;
+			status = "disabled";
+		};
+	};
 };

--- a/dts/vendor/ti/am62l_power_domains.dtsi
+++ b/dts/vendor/ti/am62l_power_domains.dtsi
@@ -139,5 +139,11 @@
 			reg = <24>;
 			#power-domain-cells = <0>;
 		};
+
+		main_rtc0_pd: power-domain@39 {
+			compatible = "arm,scmi-power-domain";
+			reg = <59>;
+			#power-domain-cells = <0>;
+		};
 	};
 };


### PR DESCRIPTION
Add and enable RTC node on AM62L evm board. Also add SCMI power domains for the same.